### PR TITLE
Allow aarsize==3 (aka 64-bit) Abstract Commands in the debug module.

### DIFF
--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -65,7 +65,7 @@ module dm_mem #(
   localparam int unsigned DbgAddressBits = 12;
   localparam int unsigned HartSelLen     = (NrHarts == 1) ? 1 : $clog2(NrHarts);
   localparam int unsigned NrHartsAligned = 2**HartSelLen;
-  localparam int unsigned MaxAar         = (BusWidth == 64) ? 4 : 3;
+  localparam int unsigned MaxAar         = 4;
   localparam bit          HasSndScratch  = (DmBaseAddress != 0);
   // Depending on whether we are at the zero page or not we either use `x0` or `x10/a0`
   localparam logic [4:0]  LoadBaseAddr   = (DmBaseAddress == 0) ? 5'd0 : 5'd10;
@@ -395,7 +395,11 @@ module dm_mem #(
             // load from data register
             abstract_cmd[2][63:32] = dm::load(ac_ar.aarsize, 5'd8, LoadBaseAddr, dm::DataAddr);
             // and store it in the corresponding CSR
-            abstract_cmd[3][31:0]  = dm::csrw(dm::csr_reg_t'(ac_ar.regno[11:0]), 5'd8);
+            if (ac_ar.aarsize == 3'd3) begin
+              abstract_cmd[3][31:0]  = dm::cspecialw(dm::spec_csr_e'(ac_ar.regno[4:0]), 5'd8);
+            end else begin
+              abstract_cmd[3][31:0]  = dm::csrw(dm::csr_reg_t'(ac_ar.regno[11:0]), 5'd8);
+            end
             // restore s0 again from dscratch
             abstract_cmd[3][63:32] = dm::cspecialr(dm::CSR_DSCRATCH0, 5'd8);
           end
@@ -436,7 +440,11 @@ module dm_mem #(
             // store s0 in dscratch
             abstract_cmd[2][31:0]  = dm::cspecialw(dm::CSR_DSCRATCH0, 5'd8);
             // read value from CSR into s0
-            abstract_cmd[2][63:32] = dm::csrr(dm::csr_reg_t'(ac_ar.regno[11:0]), 5'd8);
+            if (ac_ar.aarsize == 3'd3) begin
+              abstract_cmd[2][63:32] = dm::cspecialr(dm::spec_csr_e'(ac_ar.regno[4:0]), 5'd8);
+            end else begin
+              abstract_cmd[2][63:32] = dm::csrr(dm::csr_reg_t'(ac_ar.regno[11:0]), 5'd8);
+            end
             // and store s0 into data section
             abstract_cmd[3][31:0]  = dm::store(ac_ar.aarsize, 5'd8, LoadBaseAddr, dm::DataAddr);
             // restore s0 again from dscratch


### PR DESCRIPTION
These are already correctly handled by the AC ROM as reading/writing the cap metadata
bits for GPCRs. This diff also extends that handling to access the same bits on CSRs as well.
